### PR TITLE
feat: add logging to observe activity

### DIFF
--- a/fetchai/communication.py
+++ b/fetchai/communication.py
@@ -75,7 +75,11 @@ def lookup_endpoint_for_agent(agent_address: str) -> str:
     r.raise_for_status()
 
     request_meta["response_status"] = r.status_code
-    logger.info("Got response looking up agent endpoint")
+    logger.info(
+        "Got response looking up agent endpoint",
+        extra=request_meta,
+    )
+
     return r.json()["endpoints"][0]["url"]
 
 

--- a/fetchai/communication.py
+++ b/fetchai/communication.py
@@ -66,7 +66,10 @@ class Envelope(BaseModel):
 
 
 def lookup_endpoint_for_agent(agent_address: str) -> str:
-    request_meta = {"agent_address": agent_address, "lookup_url": DEFAULT_ALMANAC_API_URL}
+    request_meta = {
+        "agent_address": agent_address,
+        "lookup_url": DEFAULT_ALMANAC_API_URL,
+    }
     logger.debug("looking up endpoint for agent", extra=request_meta)
     r = requests.get(f"{DEFAULT_ALMANAC_API_URL}/agents/{agent_address}")
     r.raise_for_status()

--- a/fetchai/logging.py
+++ b/fetchai/logging.py
@@ -1,0 +1,3 @@
+import logging
+
+logger: logging.Logger = logging.getLogger("fetchai")

--- a/fetchai/registration.py
+++ b/fetchai/registration.py
@@ -164,4 +164,7 @@ def register_with_agentverse(
         },
     )
     r.raise_for_status()
-    logger.info("Completed registering agent with Agentverse")
+    logger.info(
+        "Completed registering agent with Agentverse",
+        extra=registration_metadata,
+    )


### PR DESCRIPTION
This adds some logging to the library, particularly where there is network IO.

I've used stdlib's `logging` with `extra` to avoid adding additional logging libraries (i.e. structlog); however to render the metadata fields a downstream client will need to install and configure python-json-logger or some other suitable log renderer that is appropriate to their use case.